### PR TITLE
Fixed starting and ending time fields in admin chat

### DIFF
--- a/wp-live-chat-support.php
+++ b/wp-live-chat-support.php
@@ -2743,11 +2743,13 @@ function wplc_draw_chat_area($cid) {
           $user_ip = __('IP Address not recorded', 'wplivechat');
       } else {
           $user_ip = "<a href='http://www.ip-adress.com/ip_tracer/" . $user_ip . "' title='".__('Whois for' ,'wplivechat')." ".$user_ip."' target='_BLANK'>".$user_ip."</a>";
-      } 
-      
-      echo "<h2>$status " . __('Chat with', 'wplivechat') . " " . $result->name . "</h2>";
-      echo "<span class='wplc-history__date'><strong>" . __( 'Starting Time:', 'wplivechat' ) . "</strong>" . date( 'Y-m-d H:i:s', current_time( strtotime( $result->timestamp ) ) ) . "</span>";
-	  echo "<span class='wplc-history__date wplc-history__date-end'><strong>" . __( 'Ending Time:', 'wplivechat' ) . "</strong>" . date( 'Y-m-d H:i:s', current_time( strtotime( $result->last_active_timestamp ) ) ) . "</span>";
+      }
+
+	echo "<h2>$status " . __( 'Chat with', 'wplivechat' ) . " " . $result->name . "</h2>";
+	if ( isset( $_GET['action'] ) && 'history' === $_GET['action'] ) {
+		echo "<span class='wplc-history__date'><strong>" . __( 'Starting Time:', 'wplivechat' ) . "</strong>" . date( 'Y-m-d H:i:s', current_time( strtotime( $result->timestamp ) ) ) . "</span>";
+		echo "<span class='wplc-history__date wplc-history__date-end'><strong>" . __( 'Ending Time:', 'wplivechat' ) . "</strong>" . date( 'Y-m-d H:i:s', current_time( strtotime( $result->last_active_timestamp ) ) ) . "</span>";
+	}
       echo "<style>#adminmenuwrap { display:none; } #adminmenuback { display:none; } #wpadminbar { display:none; } #wpfooter { display:none; } .update-nag { display:none; }</style>";
 
       echo "<div class=\"end_chat_div\">";


### PR DESCRIPTION
It removes the starting and ending time fields from admin chat window
and leave it only in history window